### PR TITLE
🐳 [GitHub] add step to validate branch name (only allow lower case letters) in docker-build.yml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,6 +40,10 @@ jobs:
         with:
           fetch-depth: 0
       -
+        name: Validate branch name
+        run: |
+          [[ $(git branch) =~ ^[[:upper:]]+$ ]] && exit 1
+      -
         name: Login to container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,7 +42,10 @@ jobs:
       -
         name: Validate branch name
         run: |
-          [[ $(git branch) =~ ^[[:upper:]]+$ ]] && exit 1
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          if [[ $branch_name =~ ^[A-Z]+$ ]]; then
+            exit 1
+          fi
       -
         name: Login to container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Wir haben andauernd Problem mit der Groß- und Kleinschreibung von Branchnamen und ich möchte keine mehr mit Großbuchstaben mehr drin haben. Man kann es immer noch einchecken, aber das wird die Leute dazu zwingen nur noch welche mit Kleinschreibung zu verwenden.

@lukaskorl Falls du eine bessere Idee hast das sicherzustellen gib Bescheid